### PR TITLE
Fix csrf token invalidated by ajax request 

### DIFF
--- a/project/templates/admin/change_form.html
+++ b/project/templates/admin/change_form.html
@@ -56,7 +56,7 @@ var csrftoken = getCookie('csrftoken');
 
 function csrfSafeMethod(method) {
     // these HTTP methods do not require CSRF protection
-    return (/^(HEAD|OPTIONS|TRACE)$/.test(method));
+    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
 }
 django.jQuery.ajaxSetup({
     complete: function(xhr, status) {

--- a/project/templates/admin/change_form.html
+++ b/project/templates/admin/change_form.html
@@ -33,7 +33,43 @@
   </ul>
 {% endif %}{% endif %}
 {% endblock %}
-<form {% if has_file_field %}enctype="multipart/form-data" {% endif %}{% if form_url %}action="{{ form_url }}" {% endif %}method="post" id="{{ opts.model_name }}_form" novalidate>{% csrf_token %}{% block form_top %}{% endblock %}
+<form {% if has_file_field %}enctype="multipart/form-data" {% endif %}{% if form_url %}action="{{ form_url }}" {% endif %}method="post" id="{{ opts.model_name }}_form" novalidate>
+  {% csrf_token %}{% block form_top %}{% endblock %}
+  <script>
+
+function getCookie(name) {
+    var cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+        var cookies = document.cookie.split(';');
+        for (var i = 0; i < cookies.length; i++) {
+            var cookie = jQuery.trim(cookies[i]);
+            // Does this cookie string begin with the name we want?
+            if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
+var csrftoken = getCookie('csrftoken');
+
+function csrfSafeMethod(method) {
+    // these HTTP methods do not require CSRF protection
+    return (/^(HEAD|OPTIONS|TRACE)$/.test(method));
+}
+django.jQuery.ajaxSetup({
+    complete: function(xhr, status) {
+      django.jQuery('[name=csrfmiddlewaretoken]').val(getCookie('csrftoken'))
+    },
+    beforeSend: function(xhr, settings) {
+        if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+            xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+        }
+    }
+});
+  </script>
+
 <div>
 {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
 {% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">{% endif %}


### PR DESCRIPTION
#63 
Cause: Ajax request invalidate form csrf token
=> Update form csrf input value according to new csrf saved in cookie.
