### PR TITLE
Missing package in requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ django-mapbox-location-field==1.6.3
 django-multiselectfield==0.1.12
 django-restful-admin==1.1.3
 django-select2==7.4.2
+django-select2-admin-filters
 django-simple-history==2.12.0
 django-smart-selects==1.5.9
 django-timezone-field==4.0


### PR DESCRIPTION
Trong file requirements bị thiếu package django-select2-admin-filters khiến việc chạy `bash run_migrate.sh` bị lỗi