### PR TITLE
Optimize Dockerfile to speedup build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,21 @@ FROM python:3
 WORKDIR /code
 
 # Node and webpack
-RUN apt-get update
-RUN apt-get install -y vim
-RUN apt-get install curl
-RUN apt-get -y install curl gnupg
-RUN curl -sL https://deb.nodesource.com/setup_11.x  | bash -
-RUN apt-get -y install nodejs
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends vim curl gnupg && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+RUN curl -sL https://deb.nodesource.com/setup_12.x  | bash -
+RUN apt-get install -y --no-install-recommends nodejs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 RUN npm install -g yarn
 
-ADD requirements.txt /code/requirements.txt
+ADD requirements.txt .
 RUN pip install -r requirements.txt
 
-RUN yarn
-
-ADD . /code/
-RUN chmod +x *.sh
+ADD package.json package-lock.json ./
+RUN yarn install
 
 # ENV should be configure from outside
 # @see docker-compose.yaml
@@ -25,5 +25,8 @@ ENV DB_USER cuuhomientrung
 ENV DB_PASSWORD cuuhomientrung
 ENV DB_HOSTNAME localhost
 ENV DB_PORT 5432
+
+ADD . /code/
+RUN chmod +x *.sh
 
 CMD ["bash","-c","env > .env && ./run_server.sh"]


### PR DESCRIPTION
Optimize `apt-get` and dependencies (Python, Javascript) installation to speed up Docker image build time.