### PR TITLE
Remove custom font

### DIFF
--- a/project/app/static/webpack_sources/scss/base/_variables.scss
+++ b/project/app/static/webpack_sources/scss/base/_variables.scss
@@ -17,7 +17,6 @@ $red-3: #B80419;
 $red-4: #83000F;
 $red-5: #350006;
 
-$font-family-sans-serif: 'Inter', sans-serif;
 $primary: $blue-3;
 $danger: $red-3;
 $body-bg: #EFF2F5;

--- a/project/templates/layout.html
+++ b/project/templates/layout.html
@@ -14,7 +14,6 @@
   <!-- Required meta tags -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
 
   {% block meta %}
     <title>Cứu hộ miền Trung</title>


### PR DESCRIPTION
As explained in #179, the custom font is unnecessary for our situation and removing it could help improving page load significantly.

Note that removing our option means that the default font choice of Bootstrap will be used. Since we are on version 4, it will be a [native font stack](https://getbootstrap.com/docs/4.5/content/reboot/#native-font-stack) which I think is really good for our case because there would be no loading or fetching at all.