### PR TITLE
Refactor ho_dan_view

### DIFF
--- a/project/app/ho_dan_views.py
+++ b/project/app/ho_dan_views.py
@@ -1,122 +1,115 @@
-import json
-from django.http import HttpResponse
-from django.shortcuts import render
-from django.core.paginator import Paginator
-from app.models import HoDan, Tinh, Huyen, Xa, TrangThaiHoDan
+from django.http import JsonResponse
+from django.views.generic import ListView
+from django.db.models import Q
 
-def get_ho_dan(status=None, tinh=None, huyen=None, xa=None):
-    query = HoDan.objects
-    if status:
-        query = query.filter(status=status)
-    if tinh:
-        query = query.filter(tinh=tinh)
-    if huyen:
-        query = query.filter(huyen=huyen)
-    if xa:
-        query = query.filter(xa=xa)
-    query = query.prefetch_related('tinh', 'huyen', 'xa', 'status', 'volunteer')\
-            .order_by('-update_time', 'id')
-    return query.all()
+from .models import HoDan, Tinh, Huyen, Xa, TrangThaiHoDan
 
-def build_params_url(status=None, tinh=None, huyen=None, xa=None):
-    url = "?"
-    if status:
-        url = url + "status=" + status + "&"
-    if tinh:
-        url = url + "tinh=" + tinh + "&"
-    if huyen:
-        url = url + "huyen=" + huyen + "&"
-    if xa:
-        url = url + "xa=" + xa + "&"
-    return url
 
-def get_tinh():
-    return Tinh.objects.order_by('name').all()
+class HoDanListView(ListView):
+    model = HoDan
+    paginate_by = 20
+    template_name = "ho_dan_index.html"
 
-def get_huyen(tinh_id=None):
-    query = Huyen.objects.prefetch_related('tinh').order_by('name')
-    if tinh_id:
-        query = query.filter(tinh=tinh_id)
-    return query.all()
+    def get(self, request, *args, **kwargs):
+        if request.is_ajax():
+            # For search query params
+            tinh = request.GET.get("tinh")
+            huyen = request.GET.get("huyen")
 
-def get_xa(huyen_id=None):
-    query = Xa.objects.prefetch_related('huyen').order_by('name')
-    if huyen_id:
-        query = query.filter(huyen=huyen_id)
-    return query.all()
+            if tinh and int(tinh) > 0:
+                list_huyen = self._get_huyen_xa_filtered(
+                    Huyen, accept_empty=False
+                ).values("id", "name")
+                dict_huyen = {huyen["id"]: huyen["name"] for huyen in list_huyen}
+                return JsonResponse(dict_huyen)
 
-def get_status():
-    return TrangThaiHoDan.objects.all()
+            if huyen and int(huyen) > 0:
+                list_xa = self._get_huyen_xa_filtered(Xa, accept_empty=False).values(
+                    "id", "name"
+                )
+                dict_xa = {xa["id"]: xa["name"] for xa in list_xa}
+                return JsonResponse(dict_xa)
 
-PAGE_SIZE = 20
+            return JsonResponse({})
 
-def get_huyen_api(request):
-    tinh = request.GET.get("tinh")
-    list_huyen = get_huyen(tinh)
-    dict_huyen = {
-        huyen.id: huyen.name
-        for huyen in list_huyen
-    }
-    return HttpResponse(json.dumps(dict_huyen), content_type="application/json")
+        return super(HoDanListView, self).get(request, *args, **kwargs)
 
-def get_xa_api(request):
-    huyen = request.GET.get("huyen")
-    list_xa = get_xa(huyen)
-    dict_xa = {
-        xa.id: xa.name
-        for xa in list_xa
-    }
-    return HttpResponse(json.dumps(dict_xa), content_type="application/json")
+    def get_queryset(self):
+        query_parms = self._get_query_params(self.request)
+        query_parms.pop("page_number")
+        query_condition = Q()
+        qs = super(HoDanListView, self).get_queryset()
 
-def index(request):
-    status = request.GET.get("status")
-    tinh = request.GET.get("tinh")
-    huyen = request.GET.get("huyen")
-    xa = request.GET.get("xa")
-    page_number = request.GET.get('page')
+        for key, val in query_parms.items():
+            if val:
+                query_condition.add(Q(**{key: val}), Q.AND)
 
-    list_ho_dan = list(get_ho_dan(
-        status=status,
-        tinh=tinh,
-        huyen=huyen,
-        xa=xa,
-    ))
+        qs = (
+            qs.filter(query_condition).prefetch_related().order_by("-update_time", "id")
+        )
+        fields = []
+        for _, field in enumerate(self.model._meta.get_fields()):
+            name = field.name
+            if field.many_to_one:
+                id_field = name + "_id"
+                name = name + "__name"
+                fields.append(id_field)
+            fields.append(name)
 
-    paginator = Paginator(list_ho_dan, PAGE_SIZE)
-    page_obj = paginator.get_page(page_number)
-    paged_list_ho_dan = page_obj.object_list
-    paged_list_dict_ho_dan = [{
-        'id': ho_dan.id,
-        'name': ho_dan.name,
-        'created_time': ho_dan.created_time,
-        'update_time': ho_dan.update_time,
-        'tinh': ho_dan.tinh,
-        'huyen': ho_dan.huyen,
-        'xa': ho_dan.xa,
-        'location': ho_dan.location,
-        'status': ho_dan.status,
-        'status_emergency': (ho_dan.status.id in [3, 5, 6]) if ho_dan.status else False,
-        'people_number': ho_dan.people_number,
-        'note': ho_dan.note,
-        'phone': ho_dan.phone,
-        'volunteer': ho_dan.volunteer,
-        'cuuho': ho_dan.cuuho,
-        'geo_location': ho_dan.geo_location,
-    } for ho_dan in paged_list_ho_dan]
-    page_obj.object_list = paged_list_dict_ho_dan
+        return qs.values(*fields)
 
-    return render(request, 'ho_dan_index.html', {
-        'page_obj': page_obj,
-        'list_status': get_status(),
-        'ho_dan_total_count': len(list_ho_dan),
-        'list_tinh': get_tinh(),
-        'list_huyen': get_huyen(tinh) if tinh else [],
-        'list_xa': get_xa(huyen) if huyen else [],
-        'params_url': build_params_url(status, tinh, huyen, xa),
-        'filtered': {
-            'status': status,
-            'tinh': tinh,
-            'huyen': huyen,
-            'xa': xa,
-        },
-    })
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["list_status"] = TrangThaiHoDan.objects.all()
+        context["ho_dan_total_count"] = self.get_queryset().count()
+        context["list_tinh"] = Tinh.objects.select_related().order_by("name").all()
+        context["list_huyen"] = self._get_huyen_xa_filtered(Huyen)
+        context["list_xa"] = self._get_huyen_xa_filtered(Xa)
+        params = self._get_query_params(self.request)
+        params.pop("page_number")
+
+        context["params_url"] = self._build_params_url(**params)
+        context["filtered"] = params
+        context["emergency_ids"] = [3, 5, 6]
+        return context
+
+    def _get_huyen_xa_filtered(self, model, accept_empty=True):
+        qs = model.objects.order_by("name")
+        tinh = self.request.GET.get("tinh", 0)
+        huyen = self.request.GET.get("huyen", 0)
+
+        tinh_id = int(tinh) if tinh and int(tinh) > 0 else None
+        huyen_id = int(huyen) if huyen and int(huyen) > 0 else None
+
+        if model.__name__ == "Huyen" and tinh_id:
+            return qs.prefetch_related("tinh").filter(tinh_id=tinh_id)
+
+        if model.__name__ == "Xa" and huyen_id:
+            return qs.prefetch_related("huyen").filter(huyen_id=huyen_id)
+
+        if not accept_empty:
+            return qs
+        return []
+
+    @staticmethod
+    def _get_query_params(request):
+        return {
+            "status": request.GET.get("status"),
+            "tinh": request.GET.get("tinh"),
+            "huyen": request.GET.get("huyen"),
+            "xa": request.GET.get("xa"),
+            "page_number": request.GET.get("page"),
+        }
+
+    @staticmethod
+    def _build_params_url(status=None, tinh=None, huyen=None, xa=None):
+        url = "?"
+        if status:
+            url = url + "status=" + status + "&"
+        if tinh:
+            url = url + "tinh=" + tinh + "&"
+        if huyen:
+            url = url + "huyen=" + huyen + "&"
+        if xa:
+            url = url + "xa=" + xa + "&"
+        return url

--- a/project/app/settings.py
+++ b/project/app/settings.py
@@ -177,9 +177,9 @@ if DEBUG:
         'debug_toolbar.middleware.DebugToolbarMiddleware', ] + MIDDLEWARE
     INTERNAL_IPS = ['localhost', '127.0.0.1', '*', ]
 
-    def show_toolbar(request):
-        return True
-    SHOW_TOOLBAR_CALLBACK = show_toolbar
+    DEBUG_TOOLBAR_CONFIG = {
+        "SHOW_TOOLBAR_CALLBACK": lambda request: True,
+    }
 
 
 ROOT_URLCONF = 'app.urls'

--- a/project/app/static/webpack_sources/js/ho_dan.js
+++ b/project/app/static/webpack_sources/js/ho_dan.js
@@ -20,7 +20,9 @@ $(document).ready(() => {
         let tinh = parseInt($("#select-tinh option:selected").val());
         let huyen = parseInt($("#select-huyen option:selected").val());
         let xa = parseInt($("#select-xa option:selected").val());
-        let new_url = "/ho_dan?";
+        const url = window.location.pathname.replace(/\/+$/, '');
+
+        let new_url = `${url}/?`;
         if (status >= 0) {
             new_url = new_url + "status=" + status + "&"
         }
@@ -37,7 +39,10 @@ $(document).ready(() => {
     });
     $('#select-tinh').on("change", function() {
         let tinh = $("#select-tinh option:selected").val();
-        $.get('/get_huyen_api/?tinh=' + tinh, function(data, err) {
+        const url = window.location.pathname.replace(/\/+$/, '');
+
+        $.get(`${url}/?tinh=${tinh}`, function(data, err) {
+            // TODO: Handle error
             $('#select-huyen').find('option').remove();
             let ele = $('<option></option>').attr("value", -1).text("Tất cả huyện");
             $("#select-huyen").append(ele);
@@ -66,7 +71,10 @@ $(document).ready(() => {
 
     $('#select-huyen').on("change", function() {
         let huyen = $("#select-huyen option:selected").val();
-        $.get('/get_xa_api/?huyen=' + huyen, function(data, err) {
+        const url = window.location.pathname.replace(/\/+$/, '');
+
+        $.get(`${url}/?huyen=${huyen}`, function(data, err) {
+            // TODO: Handle error
             $('#select-xa').find('option').remove();
             let ele = $('<option></option>').attr("value", -1).text("Tất cả xã");
             $("#select-xa").append(ele);

--- a/project/app/urls.py
+++ b/project/app/urls.py
@@ -1,26 +1,12 @@
-"""docbao_crawler URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/3.0/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
 from django.contrib import admin
-from django.urls import path, include
-from django.conf.urls import url
-from app import ho_dan_views, huong_dan_tnv_views, thong_tin_views
+from django.urls import path, include, re_path
+from django.views.decorators.cache import cache_page
+
+from app import huong_dan_tnv_views, thong_tin_views
 from django.conf import settings
 from app.admin import router
 from app.index import IndexView
-from django.views.decorators.cache import cache_page
+from app.ho_dan_views import HoDanListView
 
 _common_cache = cache_page(
     settings.VIEW_CACHE_SETTINS['common'], key_prefix=settings.REVISION
@@ -34,30 +20,22 @@ urlpatterns = [
     path('api/', include(router.urls)),
     # path('api/', rest_admin.site.urls, name="rest_api"),
     path('chaining/', include('smart_selects.urls')),
-    url(r'^admin/dynamic_raw_id/', include('dynamic_raw_id.urls')),
+    path('admin/dynamic_raw_id/', include('dynamic_raw_id.urls')),
 
     path('admin/', admin.site.urls, name="admin_home"),
     path('select2/', include('django_select2.urls')),
 
-    url(
-        r'^ho_dan$',
-        _common_cache(ho_dan_views.index),
+    re_path(
+        r'^ho_dan/?$',
+        _common_cache(HoDanListView.as_view()),
         name='home_ho_dan'
     ),
-    url(
-        r'^get_huyen_api/?$',
-        _common_cache(ho_dan_views.get_huyen_api)
-    ),
-    url(
-        r'^get_xa_api/?$',
-        _common_cache(ho_dan_views.get_xa_api)
-    ),
-    url(
+    path(
         'huong_dan_tnv/',
         _static_cache(huong_dan_tnv_views.index),
         name="home_huong_dan_tnv_url"
     ),
-    url(
+    path(
         'thong_tin/',
         _static_cache(thong_tin_views.index),
         name="home_thong_tin_url"),

--- a/project/templates/ho_dan_index.html
+++ b/project/templates/ho_dan_index.html
@@ -68,8 +68,8 @@
               <td class="citizen-td-name"> {{ hodan.name }} </td>
               <td>
                 <div class="mb-2">
-                  <span class="badge {% if hodan.status_emergency %} badge-danger {% else %} badge-info {% endif %}">
-                    {{ hodan.status }}
+                  <span class="badge {% if hodan.status_id in emergency_ids %} badge-danger {% else %} badge-info {% endif %}">
+                    {{ hodan.status__name }}
                   </span>
                 </div>
                 <div class="">
@@ -78,9 +78,9 @@
               </td>
               <td class="citizen-td-counter"> {{ hodan.people_number }} </td>
               <td class="citizen-td-address"> {{ hodan.location }}
-                {% if hodan.xa %}, {{ hodan.xa }} {% endif %}
-                {% if hodan.huyen %}, {{ hodan.huyen }} {% endif %}
-                {% if hodan.tinh %}, {{ hodan.tinh }} {% endif %}
+                {% if hodan.xa__name %}, {{ hodan.xa__name }} {% endif %}
+                {% if hodan.huyen__name %}, {{ hodan.huyen__name }} {% endif %}
+                {% if hodan.tinh__name %}, {{ hodan.tinh__name }} {% endif %}
               </td>
               <td class="citizen-td-phone"> {{ hodan.phone }} </td>
               <td>
@@ -107,8 +107,8 @@
               </h5>
             </div>
             <div class="citizen-meta">
-              <span class="badge {% if hodan.status_emergency %} badge-danger {% else %} badge-info {% endif %}">
-                {{ hodan.status }}
+              <span class="badge {% if hodan.status_id in emergency_ids %} badge-danger {% else %} badge-info {% endif %}">
+                {{ hodan.status__name }}
               </span>
               <div class="citizen-updated-time">
                 <span>Cập nhật: </span>
@@ -130,9 +130,9 @@
                 <div class="citizen-value">
                   {{ hodan.location }}
                   <ul class="citizen-location">
-                    {% if hodan.xa %}, {{ hodan.xa }} {% endif %}
-                    {% if hodan.huyen %}, {{ hodan.huyen }} {% endif %}
-                    {% if hodan.tinh %}, {{ hodan.tinh }} {% endif %}
+                    {% if hodan.xa__name %}, {{ hodan.xa__name }} {% endif %}
+                    {% if hodan.huyen__name %}, {{ hodan.huyen__name }} {% endif %}
+                    {% if hodan.tinh__name %}, {{ hodan.tinh__name }} {% endif %}
                   </ul>
                 </div>
               </div>
@@ -152,8 +152,8 @@
               <div class="citizen-info">
                 <div class="citizen-label"> Đơn vị cứu hộ</div>
                 <div class="citizen-value">
-                  {% if hodan.cuuho %}
-                    {{ hodan.cuuho }}
+                  {% if hodan.cuuho__name %}
+                    {{ hodan.cuuho__name }}
                   {% else %}
                     {{ '_ _ _ _ _' }}
                   {% endif %}
@@ -165,10 +165,10 @@
                 <span>Gửi lúc: </span>
                 <span> {{ hodan.created_time }} </span>
               </div>
-              {% if hodan.volunteer %}
+              {% if hodan.volunteer_id %}
               <div class="citizen-footer-info">
                 <span>Bởi TNV: </span>
-                <span> {{ hodan.volunteer }} </span>
+                <span> {{ hodan.volunteer__name }} </span>
               </div>
               {% endif %}
             </div>


### PR DESCRIPTION
From commit messages:

1. Show django debug toolbar panel for development environment
2. Refactor lại `ho_dan_view` để dùng `ListView` class và bỏ api cho huyện và xã.
    * Expose `huyen/xa` api chỉ để dùng cho việc tạo search param là không cần thiết.
    * Sau khi chuyển sang thành `ListView`, sửa `get` method để chấp nhận ajax get request từ frontend chứa search param.
Như vậy ta không cần phải bổ sung thêm route.
    * Trong `urls.py`, sửa lại để phù hợp với thay đổi của `ho_dan_view`, đồng thời bỏ việc dùng `url` function cũ của django vì nó đã deprecate, giờ nó chỉ là alias của path và re_path. [Read here](https://docs.djangoproject.com/en/3.1/ref/urls/#url)
3. Chỉnh lại front-end một chút cho phù hợp với thay đổi ở backend.
